### PR TITLE
Automatically purge Schedule page cache

### DIFF
--- a/cm2/admin/application/assignments.php
+++ b/cm2/admin/application/assignments.php
@@ -7,6 +7,7 @@ require_once __DIR__ .'/../../lib/database/forms.php';
 require_once __DIR__ .'/../../lib/util/util.php';
 require_once __DIR__ .'/../../lib/util/cmlists.php';
 require_once __DIR__ .'/../admin.php';
+require_once __DIR__ .'/../../../vendor/autoload.php';
 
 $context = (isset($_GET['c']) ? trim($_GET['c']) : null);
 if (!$context) {
@@ -29,6 +30,10 @@ cm_admin_check_permission('application-assignments-'.$ctx_lc, 'application-assig
 
 $apdb = new cm_application_db($db, $context);
 $midb = new cm_misc_db($db);
+
+$taskSchedulePublishable = new \App\Task\SchedulePublishableTask(
+    new \App\Hook\CloudflareApi(),
+);
 
 $list_def = array(
 	'loader' => 'server-side',
@@ -170,6 +175,7 @@ if (isset($_POST['action'])) {
 				}
 			}
 			echo json_encode($response);
+			if ($response['ok']) $taskSchedulePublishable->onScheduleManualUpdate();
 			break;
 	}
 	exit(0);

--- a/cm2/admin/application/edit.php
+++ b/cm2/admin/application/edit.php
@@ -11,6 +11,7 @@ require_once __DIR__ .'/../../lib/util/cmlists.php';
 require_once __DIR__ .'/../../lib/util/cmforms.php';
 require_once __DIR__ .'/../../lib/util/slack.php';
 require_once __DIR__ .'/../admin.php';
+require_once __DIR__ .'/../../../vendor/autoload.php';
 
 $context = (isset($_GET['c']) ? trim($_GET['c']) : null);
 if (!$context) {
@@ -56,6 +57,10 @@ $questions = $fdb->list_questions();
 $atdb = new cm_attendee_db($db);
 $mdb = new cm_mail_db($db);
 $midb = new cm_misc_db($db);
+
+$taskSchedulePublishable = new \App\Task\SchedulePublishableTask(
+    new \App\Hook\CloudflareApi(),
+);
 
 $new = !isset($_GET['id']);
 $id = $new ? -1 : (int)$_GET['id'];
@@ -250,6 +255,7 @@ if ($submitted) {
 			}
 		}
 		if ($can_edit_status) {
+			$taskSchedulePublishable->onScheduleManualUpdate();
 			if (isset($_POST['resend-application-email']) && $_POST['resend-application-email']) {
 				$application_status = strtolower($item['application-status']);
 				$template_name = 'application-' . $application_status . '-' . $ctx_lc;

--- a/cm2/lib/Hook/CloudflareApi.php
+++ b/cm2/lib/Hook/CloudflareApi.php
@@ -21,13 +21,12 @@ namespace App\Hook {
             $this->client = $client ?? HttpClient::create();
         }
 
-        public function purge( ): void
+        private function runPurge( $files = null ): void
         {
             try {
                 global $cm_config;
 
                 $bearer = $cm_config['cloudflare']['bearer_token'] ?? null;
-                $files = $cm_config['cloudflare']['purge']['files'] ?? null;
                 $zoneId = $cm_config['cloudflare']['purge']['zone_id'] ?? null;
 
                 if ($bearer === null || $files === null || $zoneId === null) {
@@ -51,6 +50,25 @@ namespace App\Hook {
             } catch (\Throwable $e) {
                 \error_log('Failed to execute Cloudflare purge : '. $e->getMessage());
             }
+        }
+
+        public function purgeSponsors( ): void
+        {
+            global $cm_config;
+            $this->runPurge(
+                $cm_config['cloudflare']['purge']['sponsor_files'] ??
+                $cm_config['cloudflare']['purge']['files'] ??
+                null
+            );
+        }
+
+        public function purgeSchedule( ): void
+        {
+            global $cm_config;
+            $this->runPurge(
+                $cm_config['cloudflare']['purge']['schedule_files'] ??
+                null
+            );
         }
     }
 }

--- a/cm2/lib/Task/SchedulePublishTask.php
+++ b/cm2/lib/Task/SchedulePublishTask.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace {
+    require_once __DIR__.'/../../../vendor/autoload.php';
+    require_once __DIR__.'/../database/misc.php';
+    require_once __DIR__ .'/../../config/config.php';
+}
+
+namespace App\Task {
+
+    use App\Hook\CloudflareApi;
+
+    readonly class SchedulePublishTask
+    {
+        public function __construct(
+            private \cm_misc_db $miscDb,
+            private CloudflareApi $cloudflareApi,
+        ) {
+        }
+
+        public function onScheduleManualUpdate(): void
+        {
+            try {
+                $this->cloudflareApi->purgeSchedule();
+            } catch (\Throwable $e) {
+                \error_log('Failed to execute task '. self::class. ': '. $e->getMessage());
+            }
+        }
+    }
+}

--- a/cm2/lib/Task/SponsorPublishableTask.php
+++ b/cm2/lib/Task/SponsorPublishableTask.php
@@ -49,7 +49,7 @@ namespace App\Task {
 
                 \apcu_store(self::class . '::last_known_hash', $sponsorsHash);
 
-                $this->cloudflareApi->purge();
+                $this->cloudflareApi->purgeSponsors();
             } catch (\Throwable $e) {
                 \error_log('Failed to execute task '. self::class. ': '. $e->getMessage());
             }

--- a/concrescent.example.php
+++ b/concrescent.example.php
@@ -42,7 +42,8 @@ $cm_config = [
         'bearer_token' => null,
         'purge' => [
             'zone_id' => null,
-            'files' => null,
+            'sponsor_files' => null,
+			'schedule_files' => null,
         ],
     ],
 


### PR DESCRIPTION
This adds an automatic Cloudflare Cache purge whenever an assignment for an event has been changed.
It also changes the config `cloudflare.files` to `cloudflare.sponsor_files` to allow the creation of `cloudflare.schedule_files`. This allows more granular purging and avoids unnecessary rebuilds.
`cloudflare.files` can still be used for sponsor files for backwards compatibility.