### PR TITLE
Fixups for the doctor to improve test output

### DIFF
--- a/cm2/admin/doctor/database1.php
+++ b/cm2/admin/doctor/database1.php
@@ -4,31 +4,38 @@ require_once __DIR__ .'/../../config/config.php';
 error_reporting(0);
 header('Content-Type: text/plain');
 
-$connection = new mysqli(
-	$cm_config['database']['host'], $cm_config['database']['username'],
-	$cm_config['database']['password'], $cm_config['database']['database']
-);
+try {
+	$connection = new mysqli(
+		$cm_config['database']['host'],
+		$cm_config['database']['username'],
+		$cm_config['database']['password'],
+		$cm_config['database']['database']
+	);
+} catch (mysqli_sql_exception $e) {
+	echo "NG Could not connect to database (code {$e->getCode()}): {$e->getMessage()}";
+	if ($e->getCode() === 2002) {
+		die('. Check if the service is running.');
+	}
+	die();
+}
+
 if (!$connection) {
-	echo 'NG Could not connect to database. Check database configuration.';
-	exit(0);
+	die('NG Could not connect to database. Check database configuration.');
 }
 
 $query = $connection->query('SELECT 6*7');
 if (!$query) {
-	echo 'NG Connection to database is not working. Check database configuration.';
-	exit(0);
+	die('NG Connection to database is not working. Check database configuration.');
 }
 
 $row = $query->fetch_row();
 if (!$row) {
-	echo 'NG Connection to database is not working. Check database configuration.';
-	exit(0);
+	die('NG Connection to database is not working. Check database configuration.');
 }
 
 $answer = $row[0];
 if ($answer != 42) {
-	echo 'NG Connection to database is not working. Check database configuration.';
-	exit(0);
+	die('NG Connection to database is not working. Check database configuration.');
 }
 
 $query->close();

--- a/cm2/admin/doctor/database3.php
+++ b/cm2/admin/doctor/database3.php
@@ -10,7 +10,14 @@ $phptime = date('Y-m-d H:i:s');
 
 $diff = abs(strtotime($dbtime) - strtotime($phptime));
 if ($diff > 600) {
-	echo 'NG MySQL time and PHP time differ by over 10 minutes. Check time zone settings, make sure time zone data is present in MySQL, and run /admin/timecheck.php to verify.';
+	exit('NG MySQL time and PHP time differ by over 10 minutes. Check time zone settings, make sure time zone data is present in MySQL, and run /admin/timecheck.php to verify.');
+}
+
+echo 'OK MySQL time and PHP time are synchronized';
+if ($diff === 0) {
+	echo ' exactly :D';
+} else if ($diff === 1) {
+	echo '. Discrepancy: 1 second.';
 } else {
-	echo 'OK MySQL time and PHP time are synchronized.';
+	echo ". Discrepancy: $diff seconds.";
 }

--- a/cm2/admin/doctor/database3.php
+++ b/cm2/admin/doctor/database3.php
@@ -10,7 +10,7 @@ $phptime = date('Y-m-d H:i:s');
 
 $diff = abs(strtotime($dbtime) - strtotime($phptime));
 if ($diff > 600) {
-	exit('NG MySQL time and PHP time differ by over 10 minutes. Check time zone settings, make sure time zone data is present in MySQL, and run /admin/timecheck.php to verify.');
+	die('NG MySQL time and PHP time differ by over 10 minutes. Check time zone settings, make sure time zone data is present in MySQL, and run /admin/timecheck.php to verify.');
 }
 
 echo 'OK MySQL time and PHP time are synchronized';

--- a/cm2/admin/doctor/database4.php
+++ b/cm2/admin/doctor/database4.php
@@ -8,13 +8,15 @@ $db = new cm_db();
 $charset = $db->connection->character_set_name();
 $charsets = $db->characterset();
 
-if (
-	$charset == 'utf8'
-	&& str_starts_with($charsets['character_set_client'], 'utf8')
-	&& str_starts_with($charsets['character_set_connection'], 'utf8')
-	&& str_starts_with($charsets['character_set_results'], 'utf8')
+// NOTE: character_set_connection === $db->connection->character_set_name()
+// The cm_db constructor sets the connection's encoding to utf8mb4,
+// and that's what all of these should be for full Unicode® support.
+if ($charsets['character_set_client'    ] === 'utf8mb4'
+ && $charsets['character_set_connection'] === 'utf8mb4'
+ && $charsets['character_set_database'  ] === 'utf8mb4'
+ && $charsets['character_set_results'   ] === 'utf8mb4'
 ) {
 	echo 'OK MySQL is using UTF-8.';
 } else {
-	echo 'NG MySQL is not using UTF-8.';
+	echo "NG MySQL is not using UTF-8. Charsets: client = $charsets[character_set_client], connection = $charsets[character_set_connection], database = $charsets[character_set_database], results = $charsets[character_set_results].";
 }

--- a/cm2/admin/doctor/magicquotes.php
+++ b/cm2/admin/doctor/magicquotes.php
@@ -1,6 +1,0 @@
-<?php
-
-error_reporting(0);
-header('Content-Type: text/plain');
-
-echo 'OK Magic Quotes is OFF.';

--- a/cm2/admin/doctor/phpversion.php
+++ b/cm2/admin/doctor/phpversion.php
@@ -3,10 +3,8 @@
 error_reporting(0);
 header('Content-Type: text/plain');
 
-if (version_compare(PHP_VERSION, '5.5') >= 0) {
-	echo 'OK PHP version is 5.5 or above.';
-} else if (version_compare(PHP_VERSION, '5') >= 0) {
-	echo 'WN PHP version is 5.0 or above, but not 5.5 or above. 5.5 or above is recommended.';
+if (version_compare(PHP_VERSION, '8.1') >= 0) {
+	echo 'OK PHP version is 8.1 or above.';
 } else {
-	echo 'NG PHP version is below 5.0. CONcrescent will not run. Other tests may fail or never finish.';
+	echo 'NG PHP version is below 8.1. CONcrescent may not function correctly, and you won\'t get security updates for PHP!';
 }

--- a/prepare
+++ b/prepare
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 ./tasks/install-env.sh
 

--- a/tasks/install-env.sh
+++ b/tasks/install-env.sh
@@ -12,5 +12,5 @@ fi
 
 if ! [[ -f concrescent.php ]]; then
   cp concrescent.example.php concrescent.php
-  echo "Edit concrescent.php file with your database, paypal, slack, event proprties, and other things."
+  echo "Edit concrescent.php file with your database, PayPal, Slack, event properties, and other things."
 fi


### PR DESCRIPTION
I've made some improvements to the CONcrescent Doctor:
 * I eliminated jQuery usage in favor of vanilla JS.
 * I made the tests run parallel as fast as possible rather than staggered-in-parallel. It can also easily be tweaked to run the tests sequentially, if desired.
 * I included more information in the error messages, such as the HTTP status code when the response isn't OK.
 * I changed phpversion.php to check for >=8.1, since 8.1 is the oldest version getting security fixes (it's over 4 years old). I also deleted magicquotes.php, which didn't actually test anything because that "feature" was removed 13 years ago in PHP 5.4.
 * database1.php now catches `mysqli_sql_exception` to report the specific error, rather than you seeing only a 500 Internal Server Error response. I also added a special-case check for the error I encountered when the mariadb service wasn't running, to suggest checking if the service is running.
 * database3.php checks how far apart the times reported by MySQL and PHP are, and passes if the difference is under 10 minutes. It now reports the time discrepancy when the test passes but the times aren't exactly the same.
 * database4.php checks if MySQL is using UTF-8. But, it did not do this correctly, presumably as a result of refactoring years ago. Instead, it always fails, even when UTF-8 is enabled. Now, the test is correct, and if it fails, it tells you what the relevant charset settings currently are.

As an aside, I also added `set -e` to the prepare script, so that it stops immediately when there's an error instead of fruitlessly continuing. And, since I noticed it while poking around when I was trying to get CONcrescent running, I fixed a typo in tasks/install-env.sh (no functional difference).